### PR TITLE
Change package name documentDatabaseTest to persistence

### DIFF
--- a/persistence.go
+++ b/persistence.go
@@ -1,4 +1,4 @@
-package documentDatabaseTest
+package persistence
 
 import (
 	"context"

--- a/persistence_test.go
+++ b/persistence_test.go
@@ -1,4 +1,4 @@
-package documentDatabaseTest
+package persistence
 
 import (
 	"context"


### PR DESCRIPTION
Updated the package name from `documentDatabaseTest` to `persistence` as part of a refactoring exercise. This refactoring aims to improve clarity and efficiency of the codebase by ensuring suitable package names are used. The change is reflected in the associated test packages and files as well.